### PR TITLE
poemgr: sleep through race condition regarding input type

### DIFF
--- a/poemgr.c
+++ b/poemgr.c
@@ -259,6 +259,14 @@ int poemgr_apply(struct poemgr_ctx *ctx)
 	/* Implicitly enable profile. */
 	poemgr_enable(ctx);
 
+	/*
+		The PoE chip might need a tiny moment before input detection.
+		On a USW-Flex powered by an 802.3at injector (TL-POE160S), it initially
+		reports a 802.3af input, which results in a low-balled power budget.
+		After the following small nap, input is correctly read as 802.3at.
+	*/
+	usleep(1);
+
 	if (!ctx->profile->apply_config)
 		return 0;
 	


### PR DESCRIPTION
Thanks for this driver, tool and package :-)

The PoE chip might need a tiny moment before input detection.
On a USW-Flex powered by an 802.3at injector (TL-POE160S), it initially
reports a 802.3af input, which results in a low-balled power budget.
After the following small nap, input is correctly read as 802.3at.

The low-balled power budget can be an actual problem. Example: the
downstream PoE consumer is an 802.3af-to-passive converter (INS-3AF-O-G)
which reports its maximum power draw of 12.6 W although the actual draw
is much lower. That means without this fix, one little consumer device
already exceeds the configured power budget.