### PR TITLE
contrib: remove unneccessary functions.sh loading

### DIFF
--- a/contrib/procd-init.sh
+++ b/contrib/procd-init.sh
@@ -6,9 +6,6 @@ USE_PROCD=1
 NAME=poemgr
 PROG=/sbin/poemgr
 
-. /lib/functions.sh
-
-
 reload_service() {
 	start
 }


### PR DESCRIPTION
It's not needed if the #! shebang already loads /etc/rc.common.

It also causes occasional host-opkg failures (e.g. when using Imagebuilder)
because something loads this init.d script during package installation.
Of course, /lib/functions.sh doesn't exist on the host.