### PR TITLE
Two power budget patches

### DIFF
--- a/contrib/usw-lite.config
+++ b/contrib/usw-lite.config
@@ -1,6 +1,7 @@
 config poemgr 'settings'
         option profile 'usw-flex'
         option disabled '1'
+        option power_budget '0'
 
 config port 'lan2'
         option name 'lan2'

--- a/poemgr.c
+++ b/poemgr.c
@@ -96,6 +96,7 @@ int poemgr_load_settings(struct poemgr_ctx *ctx, struct uci_context *uci_ctx)
 	}
 
 	ctx->settings.disabled = !!(uci_lookup_option_int(uci_ctx, section, "disabled") > 0);
+	ctx->settings.power_budget = uci_lookup_option_int(uci_ctx, section, "power_budget");
 
 	s = uci_lookup_option_string(uci_ctx, section, "profile");
 	if (!s) {

--- a/poemgr.c
+++ b/poemgr.c
@@ -266,7 +266,7 @@ int poemgr_apply(struct poemgr_ctx *ctx)
 	 * reports a 802.3af input, which results in a low-balled power budget.
 	 * After the following small nap, input is correctly read as 802.3at.
 	 */
-	usleep(1);
+	usleep(10000);
 
 	if (!ctx->profile->apply_config)
 		return 0;

--- a/poemgr.h
+++ b/poemgr.h
@@ -130,6 +130,7 @@ struct poemgr_output_status {
 
 struct poemgr_settings {
 	int disabled;
+	int power_budget;
 	char *profile;
 };
 

--- a/uswflex.c
+++ b/uswflex.c
@@ -120,9 +120,13 @@ static int poemgr_uswflex_update_port_status(struct poemgr_ctx *ctx, int port)
 
 static int poemgr_uswflex_update_output_status(struct poemgr_ctx *ctx)
 {
-	struct poemgr_pse_chip *psechip = poemgr_profile_pse_chip_get(ctx->profile, USWLFEX_NUM_PSE_CHIP_IDX);
-	int poe_budget = poemgr_uswflex_get_power_budget(poemgr_uswflex_read_power_input(ctx));
-	
+	int poe_budget;
+	if (ctx->settings.power_budget > 0) {
+		poe_budget = ctx->settings.power_budget;
+	} else {
+		poe_budget = poemgr_uswflex_get_power_budget(poemgr_uswflex_read_power_input(ctx));
+	}
+
 	ctx->output_status.power_budget = poe_budget;
 
 	return 0;
@@ -138,11 +142,17 @@ static int poemgr_uswflex_update_input_status(struct poemgr_ctx *ctx)
 static int poemgr_uswflex_apply_config(struct poemgr_ctx *ctx)
 {
 	struct poemgr_pse_chip *psechip = poemgr_profile_pse_chip_get(ctx->profile, USWLFEX_NUM_PSE_CHIP_IDX);
-	int poe_budget = poemgr_uswflex_get_power_budget(poemgr_uswflex_read_power_input(ctx));
 	struct poemgr_port_settings *port_settings;
 	int port_settings_available;
 	int port_opmode;
 	int ret = 0;
+
+	int poe_budget;
+	if (ctx->settings.power_budget > 0) {
+		poe_budget = ctx->settings.power_budget;
+	} else {
+		poe_budget = poemgr_uswflex_get_power_budget(poemgr_uswflex_read_power_input(ctx));
+	}
 
 	/* Set global power limit (Input - CPU)
 	 * Write this to all banks (a bank maps to the state of PGD[2:0]).


### PR DESCRIPTION
Two smallies, see the commit messages. Interested to see what you think about the config setting approach.

The second commit is of course only relevant for use cases that don't need to override power_budget and can instead use the default detection.