### PR TITLE
Fix compiler warning, and even a few bugs found by -Werror

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
 CC:=gcc
 OUT:=poemgr
+CFLAGS+= -Wall -Werror
 CFLAGS+=$(shell pkg-config --cflags json-c)
 LDFLAGS+=$(shell pkg-config --libs json-c) -luci
 

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 CC:=gcc
 OUT:=poemgr
-CFLAGS:=$(shell pkg-config --cflags json-c)
-LDFLAGS:=$(shell pkg-config --libs json-c) -luci
+CFLAGS+=$(shell pkg-config --cflags json-c)
+LDFLAGS+=$(shell pkg-config --libs json-c) -luci
 
 all: poemgr
 

--- a/pd69104.c
+++ b/pd69104.c
@@ -21,7 +21,8 @@ static struct pd69104_priv *pd69104_priv(struct poemgr_pse_chip *pse_chip) {
 	return (struct pd69104_priv *) pse_chip->priv;
 }
 
-static int32_t i2c_smbus_access(int file, char read_write, uint8_t command, int size, char *data)
+static int32_t i2c_smbus_access(int file, char read_write, uint8_t command,
+				int size, union i2c_smbus_data *data)
 {
 	struct i2c_smbus_ioctl_data args;
 
@@ -40,8 +41,7 @@ static int pd69104_wr(struct poemgr_pse_chip *pse_chip, uint8_t reg, uint8_t val
 
 	data.byte = val;
 
-	return i2c_smbus_access(priv->i2c_fd, I2C_SMBUS_WRITE, reg,
-							2, (char *) &data);
+	return i2c_smbus_access(priv->i2c_fd, I2C_SMBUS_WRITE, reg, 2, &data);
 }
 
 static int pd69104_rr(struct poemgr_pse_chip *pse_chip, uint8_t reg)
@@ -49,7 +49,7 @@ static int pd69104_rr(struct poemgr_pse_chip *pse_chip, uint8_t reg)
 	struct pd69104_priv *priv = pd69104_priv(pse_chip);
 	union i2c_smbus_data data;
 
-	if (i2c_smbus_access(priv->i2c_fd, I2C_SMBUS_READ, reg, 2, (char *) &data))
+	if (i2c_smbus_access(priv->i2c_fd, I2C_SMBUS_READ, reg, 2, &data))
 		return -1;
 	
 	return 0x0FF & data.byte;

--- a/poemgr.c
+++ b/poemgr.c
@@ -3,6 +3,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <uci.h>
+#include <unistd.h>
 #include <json-c/json.h>
 
 #include "poemgr.h"
@@ -23,9 +24,11 @@ static int uci_lookup_option_int(struct uci_context* uci, struct uci_section* s,
 
 static int poemgr_load_port_settings(struct poemgr_ctx *ctx, struct uci_context *uci_ctx)
 {
+	const char *disabled, *port, *name;
 	struct uci_package *package;
 	struct uci_element *e;
 	struct uci_section *s;
+	int port_idx;
 	int ret = 0;
 
 	package = uci_lookup_package(uci_ctx, "poemgr");
@@ -36,11 +39,7 @@ static int poemgr_load_port_settings(struct poemgr_ctx *ctx, struct uci_context 
 	}
 
 	uci_foreach_element(&package->sections, e) {
-		struct uci_section *s = uci_to_section(e);
-		const char *disabled;
-		const char *port;
-		const char *name;
-		int port_idx;
+		s = uci_to_section(e);
 
 		if (strcmp(s->type, "port"))
 			continue;
@@ -76,7 +75,6 @@ int poemgr_load_settings(struct poemgr_ctx *ctx, struct uci_context *uci_ctx)
 	struct uci_package *package;
 	struct uci_section *section;
 	const char *s;
-	int disabled;
 	int ret;
 
 	ret = 0;
@@ -152,18 +150,18 @@ int poemgr_show(struct poemgr_ctx *ctx)
 	for (int p_idx = 0; p_idx < ctx->profile->num_ports; p_idx++) {
 		ret = ctx->profile->update_port_status(ctx, p_idx);
 		if (ret)
-			goto out;
+			return ret;
 	}
 
 	/* Update input status */
 	ret = ctx->profile->update_input_status(ctx);
 	if (ret)
-		goto out;
+		return ret;
 
 	/* Update output status */
 	ret = ctx->profile->update_output_status(ctx);
 	if (ret)
-		goto out;
+		return ret;
 
 	/* Create JSON object */
 	root_obj = json_object_new_object();

--- a/poemgr.h
+++ b/poemgr.h
@@ -37,62 +37,6 @@ enum poemgr_metric_type {
 	POEMGR_METRIC_INT32,
 };
 
-static inline const char *poemgr_poe_type_to_string(enum poemgr_poe_type poe_type)
-{
-	if (poe_type == POEMGR_POE_TYPE_AF)
-		return "802.3af";
-	if (poe_type == POEMGR_POE_TYPE_AT)
-		return "802.3at";
-	if (poe_type == POEMGR_POE_TYPE_BT)
-		return "802.3bt";
-
-	return "unknown";
-}
-
-struct poemgr_ctx;
-
-struct poemgr_pse_chip;
-
-struct poemgr_metric {
-	enum poemgr_metric_type type;
-	char *name;
-	union {
-		char *val_char;
-		int32_t val_int32;
-	};
-};
-
-struct poemgr_pse_chip {
-	const char *model;
-
-	uint32_t portmask;
-
-	void *priv;
-
-	/* Metrics */
-	int num_metrics;
-	int (*export_metric)(struct poemgr_pse_chip *pse_chip, struct poemgr_metric *output, int metric);
-};
-
-struct poemgr_profile {
-	char *name;
-	int num_ports;
-
-	struct poemgr_pse_chip pse_chips[POEMGR_MAX_PSE_CHIPS];
-	int num_pse_chips;
-
-	void *priv;
-
-	int (*init)(struct poemgr_ctx *);
-	int (*ready)(struct poemgr_ctx *);
-	int (*enable)(struct poemgr_ctx *);
-	int (*disable)(struct poemgr_ctx *);
-	int (*apply_config)(struct poemgr_ctx *);
-	int (*update_port_status)(struct poemgr_ctx *, int port);
-	int (*update_input_status)(struct poemgr_ctx *);
-	int (*update_output_status)(struct poemgr_ctx *);
-};
-
 struct poemgr_port_settings {
 	char *name;
 	int disabled;
@@ -141,6 +85,58 @@ struct poemgr_ctx {
 	struct poemgr_input_status input_status;
 	struct poemgr_output_status output_status;
 };
+
+struct poemgr_metric {
+	enum poemgr_metric_type type;
+	char *name;
+	union {
+		char *val_char;
+		int32_t val_int32;
+	};
+};
+
+struct poemgr_pse_chip {
+	const char *model;
+
+	uint32_t portmask;
+
+	void *priv;
+
+	/* Metrics */
+	int num_metrics;
+	int (*export_metric)(struct poemgr_pse_chip *pse_chip, struct poemgr_metric *output, int metric);
+};
+
+struct poemgr_profile {
+	char *name;
+	int num_ports;
+
+	struct poemgr_pse_chip pse_chips[POEMGR_MAX_PSE_CHIPS];
+	int num_pse_chips;
+
+	void *priv;
+
+	int (*init)(struct poemgr_ctx *);
+	int (*ready)(struct poemgr_ctx *);
+	int (*enable)(struct poemgr_ctx *);
+	int (*disable)(struct poemgr_ctx *);
+	int (*apply_config)(struct poemgr_ctx *);
+	int (*update_port_status)(struct poemgr_ctx *, int port);
+	int (*update_input_status)(struct poemgr_ctx *);
+	int (*update_output_status)(struct poemgr_ctx *);
+};
+
+static inline const char *poemgr_poe_type_to_string(enum poemgr_poe_type poe_type)
+{
+	if (poe_type == POEMGR_POE_TYPE_AF)
+		return "802.3af";
+	if (poe_type == POEMGR_POE_TYPE_AT)
+		return "802.3at";
+	if (poe_type == POEMGR_POE_TYPE_BT)
+		return "802.3bt";
+
+	return "unknown";
+}
 
 static inline struct poemgr_pse_chip *poemgr_profile_pse_chip_get(struct poemgr_profile *profile, int pse_idx)
 {

--- a/uswflex.c
+++ b/uswflex.c
@@ -14,8 +14,6 @@
 
 #define USWLFEX_OWN_POWER_BUDGET	5	/* Own power budget */
 
-static struct pd69104_priv psechip;
-
 static enum poemgr_poe_type poemgr_uswflex_read_power_input(struct poemgr_ctx *ctx)
 {
 	struct poemgr_pse_chip *psechip = poemgr_profile_pse_chip_get(ctx->profile, USWLFEX_NUM_PSE_CHIP_IDX);
@@ -63,7 +61,6 @@ static int poemgr_uswflex_get_power_budget(enum poemgr_poe_type poe_type)
 
 static int poemgr_uswflex_init_chip(struct poemgr_ctx *ctx) {
 	struct poemgr_pse_chip *psechip = poemgr_profile_pse_chip_get(ctx->profile, USWLFEX_NUM_PSE_CHIP_IDX);
-	int pse_reachable;
 
 	/* Init PD69104 */
 	if (pd69104_init(psechip, 0, 0x20, USWFLEX_PSE_PORTMASK))
@@ -93,10 +90,8 @@ static int poemgr_uswflex_enable_chip(struct poemgr_ctx *ctx) {
 	return 0;
 }
 
-static int poemgr_uswflex_disable_chip(struct poemgr_ctx *ctx) {
-	struct poemgr_pse_chip *psechip = poemgr_profile_pse_chip_get(ctx->profile, USWLFEX_NUM_PSE_CHIP_IDX);
-	int pse_reachable;
-
+static int poemgr_uswflex_disable_chip(struct poemgr_ctx *ctx)
+{
 	/* Always disable chip, regardless whether it is reachable or not */
 	system("/usr/lib/poemgr/uswlite-pse-enable 1 &> /dev/null");
 
@@ -120,7 +115,6 @@ static int poemgr_uswflex_update_port_status(struct poemgr_ctx *ctx, int port)
 
 static int poemgr_uswflex_update_output_status(struct poemgr_ctx *ctx)
 {
-	struct poemgr_pse_chip *psechip = poemgr_profile_pse_chip_get(ctx->profile, USWLFEX_NUM_PSE_CHIP_IDX);
 	int poe_budget = poemgr_uswflex_get_power_budget(poemgr_uswflex_read_power_input(ctx));
 	
 	ctx->output_status.power_budget = poe_budget;


### PR DESCRIPTION
The purpose of this series is to clean up the code such that warnings-as-errors can be safely enabled. I personally like to use the combination of "-Wall" and "-Werror" because it finds many simple omissions, while not being noticeably intrusive with respect false positives on correct code.

BONUS: We even fixed a few nasty bugs that were found by -Werror, and we''re getting to a better state with fewer lines of code.