### PR TITLE
Fix minor memory leak for pd69104 and sync openwrt Makefile with upstream

### DIFF
--- a/openwrt/poemgr/Makefile
+++ b/openwrt/poemgr/Makefile
@@ -1,8 +1,13 @@
+# SPDX-License-Identifier: GPL-2.0-only
+
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=poemgr
 PKG_VERSION:=$(shell git show -s --format=%cd --date=short)
 PKG_RELEASE:=1
+
+PKG_MAINTAINER:=David Bauer <mail@david-bauer.net>
+PKG_LICENSE:=GPL-2.0-only
 
 PKG_FILE_DEPENDS:=$(CURDIR)/../..
 
@@ -17,7 +22,11 @@ define Package/poemgr
   SECTION:=utils
   CATEGORY:=Utilities
   DEPENDS:=+libuci +libjson-c
-  TITLE:=Control PoE ports on the UniFi Flex switch
+  TITLE:=Utility to control PoE ports on the UniFi Flex switch
+endef
+
+define Package/poemgr/conffiles
+/etc/config/poemgr
 endef
 
 define Package/poemgr/install

--- a/pd69104.c
+++ b/pd69104.c
@@ -262,12 +262,12 @@ int pd69104_init(struct poemgr_pse_chip *pse_chip, int i2c_bus, int i2c_addr, ui
 
 	if (fd == -1) {
 		perror(i2cpath);
-		return 1;
+		goto err_free_priv;
 	}
 
 	if (ioctl(fd, I2C_SLAVE, priv->i2c_addr) < 0) {
 		perror("i2c_set_address");
-		return 1;
+		goto err_close_fd;
 	}
 
 	priv->i2c_fd = fd;
@@ -279,6 +279,13 @@ int pd69104_init(struct poemgr_pse_chip *pse_chip, int i2c_bus, int i2c_addr, ui
 	pse_chip->export_metric = &pd69104_export_metric;
 
 	return 0;
+
+err_close_fd:
+	close(fd);
+err_free_priv:
+	free(priv);
+
+	return 1;
 }
 
 int pd69104_end(struct poemgr_pse_chip *pse_chip)


### PR DESCRIPTION
These are just two minor things which I've noticed. Not really important but just nice to have.

---

If an error happens during the initialization of the I2C PSE chip driver, then poemgr would simply stop. There is not a relevant memory leak which would affect the runtime of the poemgr.
    
But having such errors message from static analyzers (like scan-build from clang) still makes it harder to see the relevant errors.

---

There were minor changes in the Makefile from the OpenWrt packages feed which can just be integrated. This makes it easier to later sync actual relevant changes between these two Makefiles.
